### PR TITLE
PHP implementation of the descrambler/scrambler tools

### DIFF
--- a/php_descrambler/README.md
+++ b/php_descrambler/README.md
@@ -1,0 +1,22 @@
+# Descrambler
+
+Take the original dumps from the upper level directory and ouput a merged ROM file (debug) and a CPU view of the contents (final):
+
+```
+./rom_descramble.php
+```
+
+# Re-scrambler
+
+Prepare a NEW file to be scrambled:
+
+```
+cp dec_CPU_64K.bin new_CPU_64K.bin
+```
+
+then run the scrambler which will output a ROM file (debug) and two halves for physical EPROM chips (final):
+
+```
+./rom_rescramble.php
+```
+

--- a/php_descrambler/func.rom_addr.inc.php
+++ b/php_descrambler/func.rom_addr.inc.php
@@ -1,0 +1,55 @@
+<?php
+
+    /*
+        SCRAMBLING CORE (ADDRESS TRANSLATION)
+    */
+
+    function rom_addr_cpu2rom_translate($ca) {
+
+        // extract address lines to binary representation
+        $a = array();
+        for($i=0;$i<16;$i++) $a[$i] = ($ca >> $i) & 1;
+
+        // rom address
+        $r = array();
+
+        // dynamic address shuffling changes by each 32B block, thus key is A[7:5]
+        $key = array();
+        $key[2] = $a[7];
+        $key[1] = $a[6];
+        $key[0] = $a[5];
+
+        // each KEY signal controls its MUX2BOX unit (indexed as L,M,H by key weight)
+        // ( the MUX2BOX has 2 inputs and 2 outputs, and the KEY input which selects
+        //   if the data is passed straight or exchanged )
+
+        // lsb address bit 0 specifies LO/HI
+        // that passess directly (or is ignored), 16-bit system
+        $r[0] = $a[0];
+
+        // MUX2BOX_M: dynamic key MID ~ by A[6]
+        $r[1] = $key[1] ? $a[5] : $a[4];
+        $r[2] = $key[1] ? $a[4] : $a[5];
+
+        // MUX2BOX_H: dynamic key MSB ~ by A[7]
+        $r[3] = $key[2] ? $a[1] : $a[6];
+        $r[4] = $key[2] ? $a[6] : $a[1];
+
+        // msb address bit 7 put into the "middle" of the scrambler (static)
+        $r[5] = $a[7];
+
+        // MUX2BOX_L: dynamic key LSB ~ by A[5]
+        $r[6] = $key[0] ? $a[3] : $a[2];
+        $r[7] = $key[0] ? $a[2] : $a[3];
+
+        // upper addresses are same
+        for($u=8;$u<16;$u++) $r[$u] = $a[$u];
+
+        // compose read address
+        $ra = 0;
+        for($i=0;$i<16;$i++) $ra += $r[$i] ? (1 << $i) : 0;
+
+        return $ra;
+    }
+
+?>

--- a/php_descrambler/func.rom_data.inc.php
+++ b/php_descrambler/func.rom_data.inc.php
@@ -1,0 +1,83 @@
+<?php
+
+    /*
+        FILE I/O
+    */
+
+    function rom_data_load($name) {
+        return file_get_contents($name);
+    }
+
+    function rom_data_save($name,$data) {
+        return file_put_contents($name,$data);
+    }
+
+
+    /*
+        DUAL 8-bit CHIP HANDLING
+    */
+
+    function rom_data_merge($hi,$lo) {
+        $halfsize = strlen($lo);
+
+        $data = '';
+        for($i=0;$i<$halfsize;$i++) {
+            $data .= $lo[$i];
+            $data .= $hi[$i];
+        }
+
+        return $data;
+    }
+
+    function rom_data_slice($rom,$part,$parts=2) {
+        $fullsize = strlen($rom);
+
+        $data = '';
+        for($i=0;$i<$fullsize;$i+=$parts) {
+            $data .= $rom[$i+$part];
+        }
+
+        return $data;
+    }
+
+
+    /*
+        IMAGE TRANSLATION
+    */
+
+    function rom_data_decode($rom) {
+        $fullsize = strlen($rom);
+
+        // cpu: linear progression (of gathering)
+        // rom: scattered reading
+        $cpu = '';
+        for($ca=0;$ca<$fullsize;$ca++) {
+            $ra = rom_addr_cpu2rom_translate($ca);
+            $cpu .= $rom[$ra];
+        }
+
+        return $cpu;
+    }
+
+
+    function rom_data_encode($cpu) {
+        $fullsize = strlen($cpu);
+
+        // pre-clear rom image
+        // (to allow random access into PHP string)
+        $rom = '';
+        for($ca=0;$ca<$fullsize;$ca++) {
+            $rom .= chr(0xFF);
+        }
+
+        // cpu: linear progression (of source data)
+        // rom: scattered writing
+        for($ca=0;$ca<$fullsize;$ca++) {
+            $ra = rom_addr_cpu2rom_translate($ca);
+            $rom[$ra] = $cpu[$ca];
+        }
+
+        return $rom;
+    }
+
+?>

--- a/php_descrambler/rom_descramble.php
+++ b/php_descrambler/rom_descramble.php
@@ -1,0 +1,30 @@
+#!/usr/bin/php
+<?php
+
+    /*
+        Lucas Deeco SealTouch ST3220
+        ROM composer and descrambler
+
+        (C) 2025, Daniel Rozsnyo < daniel@rozsnyo.com >
+    */
+
+    require_once 'func.rom_data.inc.php';
+    require_once 'func.rom_addr.inc.php';
+
+    // load original ROM chip dumps
+    $lo = rom_data_load('../U28 27256 LO Rev K Lucas 1990.bin');
+    $hi = rom_data_load('../U10 27256 HI Rev K Lucas 1990.bin');
+
+    // assemble single ROM image in "rom address space"
+    $rom = rom_data_merge( $hi, $lo );
+
+    // debug save
+    rom_data_save('dec_ROM_64K.bin',$rom);
+
+    // read from the point of view of the CPU
+    $cpu = rom_data_decode($rom);
+
+    // final save
+    rom_data_save('dec_CPU_64K.bin',$cpu);
+
+?>

--- a/php_descrambler/rom_rescramble.php
+++ b/php_descrambler/rom_rescramble.php
@@ -1,0 +1,31 @@
+#!/usr/bin/php
+<?php
+
+    /*
+        Lucas Deeco SealTouch ST3220
+        ROM srambler and decomposer
+
+        (C) 2025, Daniel Rozsnyo < daniel@rozsnyo.com >
+    */
+
+    require_once 'func.rom_data.inc.php';
+    require_once 'func.rom_addr.inc.php';
+
+    // load NEW image for processing
+    $cpu = rom_data_load('new_CPU_64K.bin');
+
+    // apply scrambling
+    $rom = rom_data_encode($cpu);
+
+    // debug save
+    rom_data_save('new_ROM_64K.bin',$rom);
+
+    // split to LO/HI memories
+    $lo = rom_data_slice($rom,0,2);
+    $hi = rom_data_slice($rom,1,2);
+
+    // final save
+    rom_data_save('enc_U28_27256_LO_32K.bin',$lo);
+    rom_data_save('enc_U10_27256_HI_32K.bin',$hi);
+
+?>


### PR DESCRIPTION
I have implemented the address translation in a different way.
The scrambling core is more in a HDL-like form - its a combination of static and dynamic address line shuffling.
Addressing convention is in high-level / logical addresses like A[15:0] of the CPU.